### PR TITLE
change threshold number to a float

### DIFF
--- a/app/models/fern.rb
+++ b/app/models/fern.rb
@@ -5,7 +5,7 @@ class Fern < ApplicationRecord
 
   validates_presence_of :name, :health, :preferred_contact_method, :shelf_id
 
-  THRESHOLD = 0
+  THRESHOLD = 0.35
 
   def message_update(rating)
     if rating > THRESHOLD


### PR DESCRIPTION
## User Story(s) affected
- Water Fern Update & Interaction Loggin

## Describe Changes
- THRESHOLD on line 8 of `models/fern.rb` is now a float, 0.35
- All backend tests still pass, I'm not sure about FE
- Literally just one line

(Recommend pulling this branch and checking before merge.)

## Requested Reviewer(s)
Sam, Drew, or Brady (for interaction knowledge)